### PR TITLE
404エラーページ作成等

### DIFF
--- a/src/app/(contents)/[slug]/page.tsx
+++ b/src/app/(contents)/[slug]/page.tsx
@@ -1,7 +1,11 @@
 import PageComponent from "@/components/Page";
 import type { Config } from "@/types/microcms/config";
 import type { Page as PageType } from "@/types/microcms/page";
-import { getConfig, getPage, getPageIds } from "@/utils/microcms/getContents";
+import {
+  getAllPageIds,
+  getConfig,
+  getPage,
+} from "@/utils/microcms/getContents";
 import type { MicroCMSContentId, MicroCMSDate } from "microcms-js-sdk";
 import type { Metadata } from "next";
 import { notFound } from "next/navigation";
@@ -9,7 +13,7 @@ import { notFound } from "next/navigation";
 export const dynamicParams = false;
 
 export async function generateStaticParams() {
-  const pageIds: string[] = await getPageIds();
+  const pageIds: string[] = await getAllPageIds();
 
   return pageIds.map((id) => ({
     slug: id,

--- a/src/app/(contents)/posts/[slug]/page.tsx
+++ b/src/app/(contents)/posts/[slug]/page.tsx
@@ -3,9 +3,9 @@ import type { Config } from "@/types/microcms/config";
 import type { Post as PostType } from "@/types/microcms/post";
 import { generateOGP } from "@/utils/microcms/generateOGP";
 import {
+  getAllPostIds,
   getConfig,
   getPost,
-  getPostIds,
   getPosts,
 } from "@/utils/microcms/getContents";
 import type {
@@ -19,7 +19,7 @@ import { notFound } from "next/navigation";
 export const dynamicParams = false;
 
 export async function generateStaticParams() {
-  const postIds: string[] = await getPostIds();
+  const postIds: string[] = await getAllPostIds();
 
   return postIds.map((id) => ({
     slug: id,

--- a/src/app/(contents)/posts/list/[...slug]/page.tsx
+++ b/src/app/(contents)/posts/list/[...slug]/page.tsx
@@ -3,8 +3,8 @@ import type { Config } from "@/types/microcms/config";
 import type { Post } from "@/types/microcms/post";
 import { PostCategory } from "@/types/microcms/post_category";
 import {
+  getAllPostCategoryIds,
   getConfig,
-  getPostCategoryIds,
   getPostCountsByCategory,
   getPostsPaginated,
 } from "@/utils/microcms/getContents";
@@ -29,7 +29,7 @@ export async function generateStaticParams() {
     slug.push([page.toString(), ""] as string[]);
   });
   // 全カテゴリIDを取得
-  const postCategoryIds: string[] = await getPostCategoryIds();
+  const postCategoryIds: string[] = await getAllPostCategoryIds();
   // カテゴリIDとページ番号を組み合わせてスラッグを生成（/list/[カテゴリID]/[ページ数]）
   for (const id of postCategoryIds) {
     const postsByCategoryPaginated: {

--- a/src/app/(contents_dark)/works/[slug]/page.tsx
+++ b/src/app/(contents_dark)/works/[slug]/page.tsx
@@ -1,6 +1,6 @@
 import WorkComponent from "@/components/Work";
 import type { Work as WorkType } from "@/types/microcms/work";
-import { getWork, getWorkIds } from "@/utils/microcms/getContents";
+import { getAllWorkIds, getWork } from "@/utils/microcms/getContents";
 import { NoImage } from "@/utils/microcms/NoImage";
 import type { MicroCMSContentId, MicroCMSDate } from "microcms-js-sdk";
 import type { Metadata } from "next";
@@ -9,7 +9,7 @@ import { notFound } from "next/navigation";
 export const dynamicParams = false;
 
 export async function generateStaticParams() {
-  const workIds: string[] = await getWorkIds();
+  const workIds: string[] = await getAllWorkIds();
 
   return workIds.map((id) => ({
     slug: id,

--- a/src/app/(contents_dark)/works/list/[...slug]/page.tsx
+++ b/src/app/(contents_dark)/works/list/[...slug]/page.tsx
@@ -3,8 +3,8 @@ import type { Config } from "@/types/microcms/config";
 import { Group } from "@/types/microcms/group";
 import type { Work } from "@/types/microcms/work";
 import {
+  getAllGroupIds,
   getConfig,
-  getGroupIds,
   getWorksCountsByGroup,
   getWorksPaginated,
 } from "@/utils/microcms/getContents";
@@ -29,7 +29,7 @@ export async function generateStaticParams() {
     slug.push([work.toString(), ""] as string[]);
   });
   // 全カテゴリIDを取得
-  const groupIds: string[] = await getGroupIds();
+  const groupIds: string[] = await getAllGroupIds();
   // カテゴリIDとページ番号を組み合わせてスラッグを生成（/list/[カテゴリID]/[ページ数]）
   for (const id of groupIds) {
     const worksPaginated: {

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -1,0 +1,29 @@
+import Error404 from "@/components/Error404";
+import type { Config } from "@/types/microcms/config";
+import type { Work } from "@/types/microcms/work";
+import {
+  getAllWorkIds,
+  getConfig,
+  getWorks,
+} from "@/utils/microcms/getContents";
+import type { MicroCMSListResponse } from "microcms-js-sdk";
+
+export default async function NotFound() {
+  // ランダムで取得する作品の件数を定義
+  const NUMBER_OF_RANDOM_WORKS = 10;
+
+  const config: Config = await getConfig();
+  const workIds = await getAllWorkIds();
+
+  // workIdsからランダムで指定した件数を取得する
+  const randomWorkIds = workIds
+    .sort(() => Math.random() - 0.5)
+    .slice(0, NUMBER_OF_RANDOM_WORKS);
+
+  // 作品のIDを使って作品情報を取得する
+  const randomWorks: MicroCMSListResponse<Work> = await getWorks({
+    ids: randomWorkIds.join(","),
+  });
+
+  return <Error404 config={config} works={randomWorks}></Error404>;
+}

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -2,9 +2,9 @@ import type { Page } from "@/types/microcms/page";
 import type { Post } from "@/types/microcms/post";
 import type { Work } from "@/types/microcms/work";
 import {
-  getPageAllContents,
-  getPostAllContents,
-  getWorkAllContents,
+  getAllPageContents,
+  getAllPostContents,
+  getAllWorkContents,
 } from "@/utils/microcms/getContents";
 import type {
   MicroCMSContentId,
@@ -33,7 +33,7 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
 
   // 固定ページ
   const pages: (Page & MicroCMSContentId & MicroCMSDate)[] =
-    await getPageAllContents(queries);
+    await getAllPageContents(queries);
   metadata.push(
     ...pages.map((page) => ({
       url: `${BASE_URL}/${page.id}`,
@@ -43,7 +43,7 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
 
   // 記事ページ
   const posts: (Post & MicroCMSContentId & MicroCMSDate)[] =
-    await getPostAllContents(queries);
+    await getAllPostContents(queries);
   metadata.push(
     ...posts.map((post) => ({
       url: `${BASE_URL}/posts/${post.id}`,
@@ -53,7 +53,7 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
 
   // 作品ページ
   const works: (Work & MicroCMSContentId & MicroCMSDate)[] =
-    await getWorkAllContents(queries);
+    await getAllWorkContents(queries);
   metadata.push(
     ...works.map((work) => ({
       url: `${BASE_URL}/works/${work.id}`,

--- a/src/components/Error404.tsx
+++ b/src/components/Error404.tsx
@@ -48,8 +48,8 @@ function Error404({
   return (
     <>
       <Header config={config}></Header>
-      <div className="bg-zinc-100 px-6 py-16">
-        <div className="prose !max-w-none text-center">
+      <div className="bg-zinc-100 px-6 py-12 sm:py-16">
+        <div className="prose !max-w-none sm:text-center">
           <h1>ページが見つかりません</h1>
           <p>お探しのページが見つかりませんでした。</p>
           <p>
@@ -58,14 +58,14 @@ function Error404({
         </div>
       </div>
       <div className="w-full">
-        <div className="mx-6 py-16 sm:mx-auto sm:w-[65ch]">
+        <div className="mx-6 py-12 sm:mx-auto sm:w-[65ch] sm:py-16">
           {work ? (
             <>
               <div className="w-full">
                 {work.images ? (
                   // 紹介画像がある場合は、紹介画像を表示
                   <Link href={`/works/${encodeURIComponent(work.id)}`}>
-                    <div className="embla h-full w-full rounded-sm shadow-sm ring ring-slate-100">
+                    <div className="embla h-full w-full rounded-sm shadow-sm ring ring-zinc-100">
                       <div
                         className="embla__viewport h-full w-full"
                         ref={emblaRef}
@@ -123,7 +123,7 @@ function Error404({
               <div className="h-10 w-10 animate-spin rounded-full border-4 border-blue-500 border-t-transparent"></div>
             </div>
           )}
-          <div className="flex justify-center pt-16">
+          <div className="flex justify-center pt-12 sm:pt-16">
             <LinkButton href="/">トップへ戻る</LinkButton>
           </div>
         </div>

--- a/src/components/Error404.tsx
+++ b/src/components/Error404.tsx
@@ -1,0 +1,136 @@
+"use client";
+
+import Footer from "@/components/Footer";
+import Header from "@/components/Header";
+import LinkButton from "@/components/LinkButton";
+import type { Config } from "@/types/microcms/config";
+import type { Work } from "@/types/microcms/work";
+import { NoImage } from "@/utils/microcms/NoImage";
+import { setImageQuality } from "@/utils/microcms/setImageQuality";
+import { EmblaOptionsType } from "embla-carousel";
+import AutoHeight from "embla-carousel-auto-height";
+import useEmblaCarousel from "embla-carousel-react";
+import { WheelGesturesPlugin } from "embla-carousel-wheel-gestures";
+import type {
+  MicroCMSContentId,
+  MicroCMSDate,
+  MicroCMSListResponse,
+} from "microcms-js-sdk";
+import Image from "next/image";
+import Link from "next/link";
+import { useEffect, useState } from "react";
+
+function Error404({
+  config,
+  works,
+}: {
+  config: Config;
+  works: MicroCMSListResponse<Work>;
+}) {
+  // worksの中からランダムで一つの作品を取得
+  const [work, setWork] = useState<
+    (Work & MicroCMSContentId & MicroCMSDate) | null
+  >(null);
+  useEffect(() => {
+    if (works.contents.length > 0) {
+      const randomIndex = Math.floor(Math.random() * works.contents.length);
+      setWork(works.contents[randomIndex]);
+    }
+  }, [works]);
+
+  // Embla Carouselの設定
+  const options: EmblaOptionsType = { loop: true };
+  const [emblaRef] = useEmblaCarousel(options, [
+    WheelGesturesPlugin(),
+    AutoHeight(),
+  ]);
+
+  return (
+    <>
+      <Header config={config}></Header>
+      <div className="bg-zinc-100 px-6 py-16">
+        <div className="prose !max-w-none text-center">
+          <h1>ページが見つかりません</h1>
+          <p>お探しのページが見つかりませんでした。</p>
+          <p>
+            URLが間違っているか、ページが移動または削除された可能性があります。
+          </p>
+        </div>
+      </div>
+      <div className="w-full">
+        <div className="mx-6 py-16 sm:mx-auto sm:w-[65ch]">
+          {work ? (
+            <>
+              <div className="w-full">
+                {work.images ? (
+                  // 紹介画像がある場合は、紹介画像を表示
+                  <Link href={`/works/${encodeURIComponent(work.id)}`}>
+                    <div className="embla h-full w-full rounded-sm shadow-sm ring ring-slate-100">
+                      <div
+                        className="embla__viewport h-full w-full"
+                        ref={emblaRef}
+                      >
+                        <div className="embla__container h-full w-full">
+                          {work.images.map((img) => {
+                            return (
+                              <div
+                                className="embla__slide h-full w-full"
+                                key={img.url}
+                              >
+                                <Image
+                                  src={setImageQuality(img.url, {
+                                    format: "webp",
+                                    quality: "30",
+                                    width: "960",
+                                  })}
+                                  alt="紹介画像"
+                                  width={img.width}
+                                  height={img.height}
+                                  className="h-full w-full rounded-sm object-cover"
+                                />
+                              </div>
+                            );
+                          })}
+                        </div>
+                      </div>
+                    </div>
+                  </Link>
+                ) : (
+                  // 紹介画像がない場合は、画像なし
+                  <Image
+                    className="h-full w-full rounded-sm object-cover"
+                    src={NoImage.gray.url}
+                    alt="No Image"
+                    width={NoImage.gray.width}
+                    height={NoImage.gray.width}
+                  />
+                )}
+              </div>
+              <div className="mt-4 text-center">
+                <h3 className="text-lg font-bold">
+                  <Link href={`/works/${encodeURIComponent(work.id)}`}>
+                    {work?.title ?? ""}
+                  </Link>
+                </h3>
+                <Link
+                  href={`/works/${encodeURIComponent(work.id)}`}
+                  className="text-zinc-500"
+                >{`${work?.author.map((a) => a.name).join(", ")}`}</Link>
+              </div>
+            </>
+          ) : (
+            <div className="flex h-96 w-full items-center justify-center">
+              <div className="h-10 w-10 animate-spin rounded-full border-4 border-blue-500 border-t-transparent"></div>
+            </div>
+          )}
+          <div className="flex justify-center pt-16">
+            <LinkButton href="/">トップへ戻る</LinkButton>
+          </div>
+        </div>
+      </div>
+      <Footer {...config}></Footer>
+    </>
+  );
+}
+
+export default Error404;

--- a/src/components/Error404.tsx
+++ b/src/components/Error404.tsx
@@ -102,7 +102,7 @@ function Error404({
                     src={NoImage.gray.url}
                     alt="No Image"
                     width={NoImage.gray.width}
-                    height={NoImage.gray.width}
+                    height={NoImage.gray.height}
                   />
                 )}
               </div>

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -57,7 +57,7 @@ const Footer = (config: Config) => {
           </div>
           <div className="text-sm sm:text-base">
             <p>
-              ©︎2014-{new Date().getFullYear()}{" "}
+              ©︎ 2014-{new Date().getFullYear()}{" "}
               東京都市大学デジタルコンテンツ研究会
             </p>
           </div>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -88,7 +88,7 @@ const Header = ({
   return (
     <>
       <div
-        className={`${bgColorClass} ${textColorClass} fixed top-0 z-50 flex h-16 w-full items-center justify-between shadow-md lg:h-20`}
+        className={`${bgColorClass} ${textColorClass} fixed top-0 z-50 flex h-16 w-full items-center justify-between shadow-sm lg:h-20`}
       >
         <Link href="/" className="cursor-pointer">
           <Image
@@ -158,7 +158,7 @@ const Header = ({
         </div>
         <div
           // メニュー表示
-          className={`${isMenuOpen ? "opacity-100" : "invisible opacity-0"} ${navMenuBgColorClass} fixed left-0 top-16 z-50 flex h-dvh w-full flex-col items-center justify-center bg-opacity-95 shadow-md transition-opacity duration-500 lg:hidden`}
+          className={`${isMenuOpen ? "opacity-100" : "invisible opacity-0"} ${navMenuBgColorClass} fixed left-0 top-16 z-50 flex h-dvh w-full flex-col items-center justify-center bg-opacity-95 transition-opacity duration-500 lg:hidden`}
           onClick={() => setIsMenuOpen(!isMenuOpen)}
         >
           <nav className="flex flex-col items-center justify-center space-y-2">

--- a/src/components/Work.tsx
+++ b/src/components/Work.tsx
@@ -77,7 +77,7 @@ function Work({ work }: { work: Work & MicroCMSContentId & MicroCMSDate }) {
               src={NoImage.gray.url}
               alt="No Image"
               width={NoImage.gray.width}
-              height={NoImage.gray.width}
+              height={NoImage.gray.height}
             />
           )}
         </div>

--- a/src/utils/microcms/getContents.ts
+++ b/src/utils/microcms/getContents.ts
@@ -57,7 +57,7 @@ export const getGroup = async (
  * @returns {Promise<string[]>} 班IDの配列を返すPromise
  * @throws エラーが発生した場合、エラーをthrowする
  */
-export const getGroupIds = async (): Promise<string[]> => {
+export const getAllGroupIds = async (): Promise<string[]> => {
   try {
     return await apiClient.getAllContentIds({ endpoint: "groups" });
   } catch (error) {
@@ -149,7 +149,7 @@ export const getPage = async (
  * @returns {Promise<string[]>} ページIDの配列を含むPromise
  * @throws {Error} ページIDの取得に失敗した場合にエラーをthrow
  */
-export const getPageIds = async (): Promise<string[]> => {
+export const getAllPageIds = async (): Promise<string[]> => {
   try {
     return await apiClient.getAllContentIds({ endpoint: "pages" });
   } catch (error) {
@@ -163,7 +163,7 @@ export const getPageIds = async (): Promise<string[]> => {
  * @returns {Promise<(Page & MicroCMSContentId & MicroCMSDate)[]>} ページコンテンツの配列を含むPromise
  * @throws {Error} コンテンツの取得に失敗した場合にエラーをthrow
  */
-export const getPageAllContents = async (
+export const getAllPageContents = async (
   queries?: MicroCMSQueries,
 ): Promise<(Page & MicroCMSContentId & MicroCMSDate)[]> => {
   try {
@@ -216,7 +216,7 @@ export const getPost = async (
  * @returns {Promise<string[]>} 記事IDの配列を含むPromise
  * @throws エンドポイントから記事IDの取得に失敗した場合にエラーをthrow
  */
-export const getPostIds = async (): Promise<string[]> => {
+export const getAllPostIds = async (): Promise<string[]> => {
   try {
     return await apiClient.getAllContentIds({ endpoint: "posts" });
   } catch (error) {
@@ -230,7 +230,7 @@ export const getPostIds = async (): Promise<string[]> => {
  * @returns {Promise<(Post & MicroCMSContentId & MicroCMSDate)[]>} 記事コンテンツの配列を含むPromise
  * @throws {Error} コンテンツの取得に失敗した場合にエラーをthrow
  */
-export const getPostAllContents = async (
+export const getAllPostContents = async (
   queries?: MicroCMSQueries,
 ): Promise<(Post & MicroCMSContentId & MicroCMSDate)[]> => {
   try {
@@ -292,7 +292,7 @@ export const getPostCategory = async (
  * @returns {Promise<string[]>} 記事カテゴリIDの配列を含むPromise
  * @throws {Error} 記事カテゴリIDの取得に失敗した場合にエラーをthrow
  */
-export const getPostCategoryIds = async (): Promise<string[]> => {
+export const getAllPostCategoryIds = async (): Promise<string[]> => {
   try {
     return await apiClient.getAllContentIds({ endpoint: "post_categories" });
   } catch (error) {
@@ -365,7 +365,7 @@ export const getWork = async (
  * @returns {Promise<string[]>} 作品IDの配列を返すPromise
  * @throws エラーが発生した場合、エラーをthrowする
  */
-export const getWorkIds = async (): Promise<string[]> => {
+export const getAllWorkIds = async (): Promise<string[]> => {
   try {
     return await apiClient.getAllContentIds({ endpoint: "works" });
   } catch (error) {
@@ -379,7 +379,7 @@ export const getWorkIds = async (): Promise<string[]> => {
  * @returns {Promise<(Work & MicroCMSContentId & MicroCMSDate)[]>} 作品の配列を含むPromise
  * @throws {Error} 作品の取得に失敗した場合にエラーをthrow
  */
-export const getWorkAllContents = async (
+export const getAllWorkContents = async (
   queries?: MicroCMSQueries,
 ): Promise<(Work & MicroCMSContentId & MicroCMSDate)[]> => {
   try {


### PR DESCRIPTION
# 実施内容

404エラーページの作成や軽微な修正を行いました。

- 変更点
  - 404エラーページの作成
  - コンテンツ取得メソッドのメソッド名を変更、それに伴う各ページの修正
  - メニューバーの影を変更
  - フッターのコピーライトにスペースを追加

## 404エラーページ

- ランダムに1作品紹介する機能を実装
  - ビルド時に投稿済みの作品から10作品をランダムに選択
  - エラーページ表示時に10作品からランダムな1作品を表示

### 画面キャプチャ

![image](https://github.com/user-attachments/assets/da9a01c9-ef82-4ab8-a638-e1d243195ebc)
